### PR TITLE
Fix double-encoded `oembed` link

### DIFF
--- a/templates/embed.njk
+++ b/templates/embed.njk
@@ -21,7 +21,7 @@
 
     <title>{{ title }} (@{{ author }})</title>
 
-    <link type="application/json+oembed" href="{{ oembed }}"/>
+    <link type="application/json+oembed" href="{{ oembed | safe }}"/>
 
     <!-- Ensure that directly loading this page results in redirect (should happen at the HTTP level) -->
     <script>window.location.replace("{{ link }}");</script>


### PR DESCRIPTION
Nunjuks was sanitizing the string, encoding `&` as `&amp;`. We build the URL ourselves, and the only external data is made HTML safe by `URLSearchParams`.