### PR TITLE
Serve `robots.txt` to disable crawling

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -193,7 +193,7 @@ router.get("/oembed.json", ctx => {
     ctx.response.body = JSON.stringify(oembed);
 });
 
-router.get("/style.css", async ctx => {
+router.get("/(style.css|robots.txt)", async ctx => {
     await ctx.send({
         root: './static'
     });

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,3 @@
+# We have nothing interesting to crawl. Every page should be a redirect.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
There's theoretically nothing to crawl, since everything is a redirect. If a crawler hits one of our links, they can follow it. The main AI Dungeon site should be the canonical source.