### PR TITLE
Show a demo when embedding `/`

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -237,7 +237,7 @@ router.get("/oembed.json", ctx => {
     }
     const oembed = {
         provider_name: 'AI Dungeon ' + params.get("type"),
-        provider_url: config.client.origin,
+        provider_url: params.get('type') === "Embed Fix" ? "https://github.com/ndm13/aid-embed-fix" : config.client.origin,
         title: "Embed",
         type: 'rich',
         version: '1.0'
@@ -261,8 +261,30 @@ router.get("/(style.css|robots.txt)", async ctx => {
 
 router.get("/", ctx => {
     last.root = Date.now();
-    ctx.response.status = 301;
-    ctx.response.redirect("https://github.com/ndm13/aid-embed-fix");
+    if (shouldForwardInstead(ctx)) {
+        ctx.response.status = 301;
+        ctx.response.redirect("https://github.com/ndm13/aid-embed-fix");
+        return;
+    }
+    // Otherwise generate embed demo
+    const oembedParams = new URLSearchParams({
+        title: "Fix AI Dungeon Link Previews!",
+        type: "Embed Fix"
+    });
+    ctx.response.body = njk.render("demo.njk", {
+        title: "Fix AI Dungeon Link Previews!",
+        description: `Get more details in your AI Dungeon links!
+ • Change .com to .link, or
+ • Post a link and type s/i/x!
+
+Now you can see the link type, description, and image!
+
+Fully open source, click the link for details!`,
+        cover: 'https://github.com/ndm13/aid-embed-fix/blob/main/screenshots/sixfix_demo.gif?raw=true',
+        oembed: `${config.network.oembedProtocol}://${ctx.request.url.host}/oembed.json?${oembedParams}`,
+        link: "https://github.com/ndm13/aid-embed-fix",
+        author: "ndm13"
+    });
 });
 
 const app = new Application();

--- a/templates/demo.njk
+++ b/templates/demo.njk
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="theme-color" content="#f8ae2c"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta property="twitter:title" content="{{ title }}"/>
+    <meta property="og:title" content="{{ title }}"/>
+    <meta property="og:description" content="{{ description }}"/>
+    <meta property="description" content="{{ description }}"/>
+    <meta property="twitter:image" content="{{ cover }}"/>
+    <meta property="og:image" content="{{ cover }}"/>
+    <meta property="og:type" content="article"/>
+    <meta name="application-name" content="AI Dungeon Embed Fix"/>
+    <meta property="og:site_name" content="AI Dungeon Embed Fix"/>
+
+    <link rel="canonical" href="{{ link }}>"/>
+    <meta property="og:url" content="{{ link }}"/>
+
+    <meta name="redirect" content="{{ link }}"/>
+
+    <title>{{ title }}</title>
+
+    <link type="application/json+oembed" href="{{ oembed | safe }}"/>
+
+    <!-- Ensure that directly loading this page results in redirect (should happen at the HTTP level) -->
+    <script>window.location.replace("{{ link }}");</script>
+
+    <!-- Okay you heathens, have a nice looking page -->
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="/style.css"/>
+</head>
+<body class="embed">
+<h2><a href="{{ link }}">{{ title }}</a></h2>
+<h5>a web app by <a href="{{ profile_link }}">{{ author }}</a></h5>
+<p>{{ description }}</p>
+<img src="{{ cover }}"/>
+</body>
+</html>


### PR DESCRIPTION
- Added `demo.njk`
- Added custom logic to `oembed.json` to handle the special case