### PR TITLE
Fix issue with old CDN covers not rendering

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -33,7 +33,7 @@
         "jsr:@std/bytes",
         "jsr:@std/crypto@1",
         "jsr:@std/encoding@1",
-        "jsr:@std/http",
+        "jsr:@std/http@1",
         "jsr:@std/media-types"
       ]
     },
@@ -43,7 +43,7 @@
         "jsr:@oak/commons",
         "jsr:@std/assert",
         "jsr:@std/bytes",
-        "jsr:@std/http",
+        "jsr:@std/http@1",
         "jsr:@std/media-types",
         "jsr:@std/path",
         "npm:path-to-regexp"

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -76,7 +76,8 @@ export class Renderer {
             author: scenario.user.profile.title,
             profile_link: `${config.client.origin}/profile/${scenario.user.profile.title}`,
             description: trimDescription(scenario.description ?? scenario.prompt ?? ""),
-            cover: ctx.request.url.searchParams.get("bi") ?? `${scenario.image}/public`,
+            cover: ctx.request.url.searchParams.get("bi") ??
+                        scenario.image.endsWith('.png') ? scenario.image : `${scenario.image}/public`,
             link,
             icon: scenario.user.profile.thumbImageUrl,
             oembed: Renderer.oembedLink(ctx, {
@@ -94,7 +95,8 @@ export class Renderer {
             author: adventure.user.profile.title,
             profile_link: `${config.client.origin}/profile/${adventure.user.profile.title}`,
             description: trimDescription(adventure.description ?? ""),
-            cover: ctx.request.url.searchParams.get("bi") ?? `${adventure.image}/public`,
+            cover: ctx.request.url.searchParams.get("bi") ??
+                        adventure.image.endsWith('.png') ? adventure.image :  `${adventure.image}/public`,
             link,
             icon: adventure.user.profile.thumbImageUrl,
             oembed: Renderer.oembedLink(ctx, {


### PR DESCRIPTION
- All cover URLs ending in `.png` will not have `/public` appended to the link before serving it