### PR TITLE
Build dashboard as part of binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           deno-version: v2.7.x
 
+      - name: Build Dashboard
+        run: deno task dashboard:build
+
       - name: Compile Binary
         run: |
           if [[ "${{ matrix.target }}" == *"windows"* ]]; then


### PR DESCRIPTION
Minor fix for binary build process where dashboard files weren't included as part of the bundle.