### PR TITLE
Suppress logging from `serveDir`

### DIFF
--- a/src/support/vfs.ts
+++ b/src/support/vfs.ts
@@ -14,6 +14,7 @@ export async function serveStatic(ctx: Context<any>, vfsPath: string, rewritePat
     let res = await serveDir(req, {
         fsRoot,
         showIndex: true,
+        quiet: true
     });
 
     if (res.status === 404 && fallbackIndex) {
@@ -25,6 +26,7 @@ export async function serveStatic(ctx: Context<any>, vfsPath: string, rewritePat
         res = await serveDir(fallbackReq, {
             fsRoot,
             showIndex: true,
+            quiet: true
         });
     }
 


### PR DESCRIPTION
The `serveDir` function from `jsr:@std/http@^1.1.2/file-server` has native logging enabled by default. Suppressing this to clean up log output, since we already log these requests.